### PR TITLE
handle error when accessing RawImage in LidarV2

### DIFF
--- a/Assets/1_SelfDrivingCar/Scripts/LidarV2.cs
+++ b/Assets/1_SelfDrivingCar/Scripts/LidarV2.cs
@@ -79,16 +79,18 @@ public class LidarV2 : MonoBehaviour
 		frameRenderCounter = 0;
 		frameActualRenderTimes = 0;
 		Render(ref nextImage, ref nextStartColumns, ref sampleCount);
-		
-		while (sampleCount > 0) {
-			nextImage.Apply();
-			lastImage = nextImage;
-			rawImage.texture = lastImage;
-			nextImage = new Texture2D(CloudWidth, Channels, TextureFormat.RGB24, false);
-			Render(ref nextImage, ref nextStartColumns, ref sampleCount);
-		}
 
-		Debug.LogFormat("DeltaTime:{0}, RenderTimes:{1}, ActualRenderTiems:{2}", Time.deltaTime, frameRenderCounter, frameActualRenderTimes);
+        try {
+            while (sampleCount > 0) {
+			    nextImage.Apply();
+			    lastImage = nextImage;
+			    rawImage.texture = lastImage;
+			    nextImage = new Texture2D(CloudWidth, Channels, TextureFormat.RGB24, false);
+			    Render(ref nextImage, ref nextStartColumns, ref sampleCount);
+		    }
+        } catch (System.Exception e) { }
+
+        Debug.LogFormat("DeltaTime:{0}, RenderTimes:{1}, ActualRenderTiems:{2}", Time.deltaTime, frameRenderCounter, frameActualRenderTimes);
 	}
 
 	// return successfully rendered fragment width

--- a/Assets/SampleScenes/Shaders/Skybox-Procedural.shader
+++ b/Assets/SampleScenes/Shaders/Skybox-Procedural.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Upgrade NOTE: replaced '_Object2World' with 'unity_ObjectToWorld'
 
 Shader "Skybox/Procedural" {
@@ -87,7 +89,7 @@ SubShader {
 		v2f vert (appdata_t v)
 		{
 			v2f OUT;
-			OUT.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+			OUT.pos = UnityObjectToClipPos(v.vertex);
 
 			float3 cameraPos = float3(0,kInnerRadius + kCameraHeight,0); 	// The camera's current position
 		

--- a/Assets/SphereMapImageEffect.mat
+++ b/Assets/SphereMapImageEffect.mat
@@ -10,139 +10,76 @@ Material:
   m_Shader: {fileID: 4800000, guid: 460b2f1b1fe577448973cc611c42846d, type: 3}
   m_ShaderKeywords: _EMISSION
   m_LightmapFlags: 1
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
+  disabledShaderPasses: []
   m_SavedProperties:
-    serializedVersion: 2
+    serializedVersion: 3
     m_TexEnvs:
-    - first:
-        name: _BumpMap
-      second:
+    - _BumpMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - first:
-        name: _DetailAlbedoMap
-      second:
+    - _DetailAlbedoMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - first:
-        name: _DetailMask
-      second:
+    - _DetailMask:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - first:
-        name: _DetailNormalMap
-      second:
+    - _DetailNormalMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - first:
-        name: _EmissionMap
-      second:
+    - _EmissionMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - first:
-        name: _MainTex
-      second:
+    - _MainTex:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - first:
-        name: _MaskTex
-      second:
+    - _MaskTex:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - first:
-        name: _MetallicGlossMap
-      second:
+    - _MetallicGlossMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - first:
-        name: _OcclusionMap
-      second:
+    - _OcclusionMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - first:
-        name: _ParallaxMap
-      second:
+    - _ParallaxMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
-    - first:
-        name: _BumpScale
-      second: 1
-    - first:
-        name: _Cutoff
-      second: 0.5
-    - first:
-        name: _DetailNormalMapScale
-      second: 1
-    - first:
-        name: _DstBlend
-      second: 0
-    - first:
-        name: _Fov
-      second: 90
-    - first:
-        name: _GlossMapScale
-      second: 1
-    - first:
-        name: _Glossiness
-      second: 0.5
-    - first:
-        name: _GlossyReflections
-      second: 1
-    - first:
-        name: _Metallic
-      second: 0
-    - first:
-        name: _Mode
-      second: 0
-    - first:
-        name: _OcclusionStrength
-      second: 1
-    - first:
-        name: _Parallax
-      second: 0.02
-    - first:
-        name: _SmoothnessTextureChannel
-      second: 0
-    - first:
-        name: _SpecularHighlights
-      second: 1
-    - first:
-        name: _SrcBlend
-      second: 1
-    - first:
-        name: _SupersampleScale
-      second: 1
-    - first:
-        name: _UVSec
-      second: 0
-    - first:
-        name: _WidthScale
-      second: 1
-    - first:
-        name: _ZWrite
-      second: 1
-    - first:
-        name: _maskBlend
-      second: 0.5
-    - first:
-        name: _maskSize
-      second: 1
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _Fov: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SupersampleScale: 0
+    - _UVSec: 0
+    - _WidthScale: 1
+    - _ZWrite: 1
+    - _maskBlend: 0.5
+    - _maskSize: 1
     m_Colors:
-    - first:
-        name: _Color
-      second: {r: 1, g: 1, b: 1, a: 1}
-    - first:
-        name: _EmissionColor
-      second: {r: 0, g: 0, b: 0, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/Standard Assets/Effects/GlassRefraction/Shaders/GlassStainedBumpDistort.shader
+++ b/Assets/Standard Assets/Effects/GlassRefraction/Shaders/GlassStainedBumpDistort.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Per pixel bumped refraction.
 // Uses a normal map to distort the image behind, and
 // an additional texture to tint the color.
@@ -56,7 +58,7 @@ float4 _MainTex_ST;
 v2f vert (appdata_t v)
 {
 	v2f o;
-	o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+	o.vertex = UnityObjectToClipPos(v.vertex);
 	#if UNITY_UV_STARTS_AT_TOP
 	float scale = -1.0;
 	#else

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/BlendModesOverlay.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/BlendModesOverlay.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BlendModesOverlay" {
 	Properties {
 		_MainTex ("Screen Blended", 2D) = "" {}
@@ -22,7 +24,7 @@ Shader "Hidden/BlendModesOverlay" {
 		
 	v2f vert( appdata_img v ) { 
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		
 		o.uv[0] = float2(
 			dot(v.texcoord.xy, _UV_Transform.xy),

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/BlurEffectConeTaps.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/BlurEffectConeTaps.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BlurEffectConeTap" {
 	Properties { _MainTex ("", any) = "" {} }
 	CGINCLUDE
@@ -12,7 +14,7 @@ Shader "Hidden/BlurEffectConeTap" {
 	half4 _BlurOffsets;
 	v2f vert( appdata_img v ) {
 		v2f o; 
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord - _BlurOffsets.xy * _MainTex_TexelSize.xy; // hack, see BlurEffect.cs for the reason for this. let's make a new blur effect soon
 		o.taps[0] = o.uv + _MainTex_TexelSize * _BlurOffsets.xy;
 		o.taps[1] = o.uv - _MainTex_TexelSize * _BlurOffsets.xy;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/CameraMotionBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/CameraMotionBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
  /*
  	CAMERA MOTION BLUR IMAGE EFFECTS
 
@@ -88,7 +90,7 @@
 	v2f vert(appdata_img v) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		return o;
 	}

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/CameraMotionBlurDX11.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/CameraMotionBlurDX11.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
  /*
  	NOTES: see CameraMotionBlur.shader
  */
@@ -50,7 +52,7 @@
 	v2f vert(appdata_img v) 
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv = v.texcoord.xy;
 		return o;
 	}

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ChromaticAberrationShader.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ChromaticAberrationShader.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ChromaticAberration" {
 	Properties {
 		_MainTex ("Base", 2D) = "" {}
@@ -23,7 +25,7 @@ Shader "Hidden/ChromaticAberration" {
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		
 		return o;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrection3DLut.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrection3DLut.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ColorCorrection3DLut" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}		
@@ -21,7 +23,7 @@ float _Offset;
 v2f vert( appdata_img v ) 
 {
 	v2f o;
-	o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos(v.vertex);
 	o.uv =  v.texcoord.xy;	
 	return o;
 } 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrectionCurves.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrectionCurves.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ColorCorrectionCurves" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -39,7 +41,7 @@ Shader "Hidden/ColorCorrectionCurves" {
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv =  v.texcoord.xy;
 		o.uv2 = TRANSFORM_TEX(v.texcoord, _CameraDepthTexture);
 		

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrectionCurvesSimple.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrectionCurvesSimple.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ColorCorrectionCurvesSimple" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -21,7 +23,7 @@ Shader "Hidden/ColorCorrectionCurvesSimple" {
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		return o;
 	} 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrectionSelective.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrectionSelective.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ColorCorrectionSelective" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -19,7 +21,7 @@ Shader "Hidden/ColorCorrectionSelective" {
 	
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv = v.texcoord.xy;
 		return o;
 	} 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/Contrast Stretch/Apply.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/Contrast Stretch/Apply.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Final pass in the contrast stretch effect: apply
 // color stretch to the original image, based on currently
 // adapted to minimum/maximum luminances.
@@ -29,7 +31,7 @@ uniform sampler2D _AdaptTex;
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv[0] = MultiplyUV (UNITY_MATRIX_TEXTURE0, v.texcoord);
 	o.uv[1] = float2(0.5,0.5);
 	return o;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/Contrast Stretch/MinMaxReduction.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/Contrast Stretch/MinMaxReduction.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Reduces input image (_MainTex) by 2x2.
 // Outputs maximum value in R, minimum in G.
 Shader "Hidden/Contrast Stretch Reduction" {
@@ -25,7 +27,7 @@ uniform sampler2D _MainTex;
 
 v2f vert (appdata_img v) {
 	v2f o;
-	o.position = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.position = UnityObjectToClipPos (v.vertex);
 	float2 uv = MultiplyUV (UNITY_MATRIX_TEXTURE0, v.texcoord);
 	
 	// Compute UVs to sample 2x2 pixel block.

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ContrastComposite.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ContrastComposite.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ContrastComposite" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -24,7 +26,7 @@ Shader "Hidden/ContrastComposite" {
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		
 		o.uv[0] = v.texcoord.xy;
 		o.uv[1] = v.texcoord.xy;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ConvertDepth.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ConvertDepth.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ConvertDepth" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -19,7 +21,7 @@ Shader "Hidden/ConvertDepth" {
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv =  v.texcoord.xy;
 		return o;
 	}

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/CreaseApply.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/CreaseApply.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 
 Shader "Hidden/CreaseApply" {
@@ -32,7 +34,7 @@ struct v2f {
 v2f vert( appdata_img v )
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv.xy = v.texcoord.xy;
 	return o;
 }

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/EdgeDetectNormals.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/EdgeDetectNormals.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/EdgeDetect" { 
 	Properties {
@@ -40,7 +42,7 @@ Shader "Hidden/EdgeDetect" {
 	v2flum vertLum (appdata_img v)
 	{
 		v2flum o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		float2 uv = MultiplyUV( UNITY_MATRIX_TEXTURE0, v.texcoord );
 		o.uv[0] = uv;
 		o.uv[1] = uv + float2(-_MainTex_TexelSize.x, -_MainTex_TexelSize.y) * _SampleDistance;
@@ -90,7 +92,7 @@ Shader "Hidden/EdgeDetect" {
 	v2f vertRobert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		
 		float2 uv = v.texcoord.xy;
 		o.uv[0] = uv;
@@ -114,7 +116,7 @@ Shader "Hidden/EdgeDetect" {
 	v2f vertThin( appdata_img v )
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		
 		float2 uv = v.texcoord.xy;
 		o.uv[0] = uv;
@@ -137,7 +139,7 @@ Shader "Hidden/EdgeDetect" {
 	v2fd vertD( appdata_img v )
 	{
 		v2fd o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		
 		float2 uv = v.texcoord.xy;
 		o.uv[0] = uv;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/FisheyeShader.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/FisheyeShader.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/FisheyeShader" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -20,7 +22,7 @@ Shader "Hidden/FisheyeShader" {
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		return o;
 	} 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/GlobalFog.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/GlobalFog.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/GlobalFog" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "black" {}
@@ -44,7 +46,7 @@ CGINCLUDE
 		v2f o;
 		half index = v.vertex.z;
 		v.vertex.z = 0.1;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		o.uv_depth = v.texcoord.xy;
 		

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/MotionBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/MotionBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/MotionBlur" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -36,7 +38,7 @@ Properties {
 			v2f vert (appdata_t v)
 			{
 				v2f o;
-				o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+				o.vertex = UnityObjectToClipPos(v.vertex);
 				o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
 				return o;
 			}
@@ -80,7 +82,7 @@ Properties {
 			v2f vert (appdata_t v)
 			{
 				v2f o;
-				o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+				o.vertex = UnityObjectToClipPos(v.vertex);
 				o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
 				return o;
 			}

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/MotionBlurClear.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/MotionBlurClear.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/MotionBlurClear" 
 {
@@ -31,7 +33,7 @@ Pass {
 	ps_input vert (vs_input v)
 	{
 		ps_input o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);	
+		o.pos = UnityObjectToClipPos (v.vertex);	
 		o.screen = ComputeScreenPos(o.pos);
 		COMPUTE_EYEDEPTH(o.screen.z);
 		return o;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseAndGrain.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseAndGrain.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/NoiseAndGrain" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -47,7 +49,7 @@ Shader "Hidden/NoiseAndGrain" {
 		{
 			v2f o;
 			
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);	
+			o.pos = UnityObjectToClipPos (v.vertex);	
 			
 		#if UNITY_UV_STARTS_AT_TOP
 			o.uv_screen = v.vertex.xyxy;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseAndGrainDX11.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseAndGrainDX11.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/NoiseAndGrainDX11" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -72,7 +74,7 @@ Shader "Hidden/NoiseAndGrainDX11" {
 		{
 			v2f o;
 			
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);	
+			o.pos = UnityObjectToClipPos (v.vertex);	
 			
 		#if UNITY_UV_STARTS_AT_TOP
 			o.uv_screen = v.vertex.xyxy;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseEffectShaderRGB.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseEffectShaderRGB.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Noise Shader RGB" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -32,7 +34,7 @@ uniform fixed4 _Intensity; // x=grain, y=scratch
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = MultiplyUV (UNITY_MATRIX_TEXTURE0, v.texcoord);
 	o.uvg = v.texcoord.xy * _GrainOffsetScale.zw + _GrainOffsetScale.xy;
 	o.uvs = v.texcoord.xy * _ScratchOffsetScale.zw + _ScratchOffsetScale.xy;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseEffectShaderYUV.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseEffectShaderYUV.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Noise Shader YUV" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -32,7 +34,7 @@ uniform fixed4 _Intensity; // x=grain, y=scratch
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = MultiplyUV (UNITY_MATRIX_TEXTURE0, v.texcoord);
 	o.uvg = v.texcoord.xy * _GrainOffsetScale.zw + _GrainOffsetScale.xy;
 	o.uvs = v.texcoord.xy * _ScratchOffsetScale.zw + _ScratchOffsetScale.xy;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/PrepareSunShaftsBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/PrepareSunShaftsBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/PrepareSunShaftsBlur" {
 	Properties {
@@ -23,7 +25,7 @@ Shader "Hidden/PrepareSunShaftsBlur" {
 		
 	v2f vert (appdata_img v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		return o;
 	}  

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/RadialBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/RadialBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/RadialBlur" 
 {
 	Properties {
@@ -24,7 +26,7 @@ Shader "Hidden/RadialBlur"
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy =  v.texcoord.xy;
 		
 		o.blurVector = (_SunPosition.xy - v.texcoord.xy) * _BlurRadius4.xy;	

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/SSAOShader.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/SSAOShader.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/SSAO" {
 Properties {
 	_MainTex ("", 2D) = "" {}
@@ -22,7 +24,7 @@ float4 _CameraDepthNormalsTexture_ST;
 v2f_ao vert_ao (appdata_img v)
 {
 	v2f_ao o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = TRANSFORM_TEX(v.texcoord, _CameraDepthNormalsTexture);
 	o.uvr = v.texcoord.xy * _NoiseScale;
 	return o;
@@ -184,7 +186,7 @@ float4 _MainTex_ST;
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = TRANSFORM_TEX (v.texcoord, _CameraDepthNormalsTexture);
 	return o;
 }
@@ -253,7 +255,7 @@ struct v2f {
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv[0] = MultiplyUV (UNITY_MATRIX_TEXTURE0, v.texcoord);
 	o.uv[1] = MultiplyUV (UNITY_MATRIX_TEXTURE1, v.texcoord);
 	return o;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ScreenSpaceAmbientObscurance.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ScreenSpaceAmbientObscurance.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 // This Ambient Occlusion image effect is based on "Scalable Ambient Obscurance":
 
@@ -74,7 +76,7 @@ Shader "Hidden/ScreenSpaceAmbientObscurance"
 	v2f vert( appdata_img v )
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		o.uv2 = v.texcoord.xy;
 		#if UNITY_UV_STARTS_AT_TOP

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ShowAlphaChannel.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ShowAlphaChannel.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 
 Shader "Hidden/ShowAlphaChannel" {
@@ -31,7 +33,7 @@ struct v2f {
 v2f vert( appdata_img v )
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = v.texcoord.xy;
 	
 	return o;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/SimpleClear.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/SimpleClear.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 
 Shader "Hidden/SimpleClear" {
@@ -24,7 +26,7 @@ struct v2f {
 v2f vert( appdata_img v )
 {
 	v2f o;
-	o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos(v.vertex);
 	return o;
 }
 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/SunShaftsComposite.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/SunShaftsComposite.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/SunShaftsComposite" {
 	Properties {
 		_MainTex ("Base", 2D) = "" {}
@@ -40,7 +42,7 @@ Shader "Hidden/SunShaftsComposite" {
 			
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		
 		#if UNITY_UV_STARTS_AT_TOP
@@ -76,7 +78,7 @@ Shader "Hidden/SunShaftsComposite" {
 	
 	v2f_radial vert_radial( appdata_img v ) {
 		v2f_radial o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		
 		o.uv.xy =  v.texcoord.xy;
 		o.blurVector = (_SunPosition.xy - v.texcoord.xy) * _BlurRadius4.xy;	

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/Tonemapper.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/Tonemapper.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Tonemapper" {
 	Properties {
 		_MainTex ("", 2D) = "black" {}
@@ -28,7 +30,7 @@ Shader "Hidden/Tonemapper" {
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		return o;
 	} 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/TwirlEffect.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/TwirlEffect.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Twirt Effect Shader" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -25,7 +27,7 @@ struct v2f {
 v2f vert( appdata_img v )
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = v.texcoord - _CenterRadius.xy;
 	return o;
 }

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/VignettingShader.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/VignettingShader.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Vignetting" {
 	Properties {
 		_MainTex ("Base", 2D) = "white" {}
@@ -24,7 +26,7 @@ Shader "Hidden/Vignetting" {
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		o.uv2 = v.texcoord.xy;
 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/VortexEffect.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/VortexEffect.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Twist Effect" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -32,7 +34,7 @@ struct v2f {
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos(v.vertex);
 	float2 uv = v.texcoord.xy - _CenterRadius.xy;
 	o.uv = TRANSFORM_TEX(uv, _MainTex); //MultiplyUV (UNITY_MATRIX_TEXTURE0, uv);
 	o.uvOrig = uv;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/DLAA.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/DLAA.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 //
 // modified and adapted DLAA code based on Dmitry Andreev's
@@ -278,7 +280,7 @@ CGINCLUDE
 
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		
 		float2 uv = v.texcoord.xy;
 		o.uv.xy = uv;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAA2.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAA2.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/FXAA II" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -167,7 +169,7 @@ float4 _MainTex_TexelSize;
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = FxaaVertexShader (v.texcoord.xy*2-1, _MainTex_TexelSize.xy);
 	return o;
 }

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAA3Console.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAA3Console.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 
 /*============================================================================
@@ -64,7 +66,7 @@ Shader "Hidden/FXAA III (Console)" {
 		v2f vert (appdata_img v)
 		{
 			v2f o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = v.texcoord.xy;
 			

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAAPreset2.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAAPreset2.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/FXAA Preset 2" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -806,7 +808,7 @@ struct v2f {
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = v.texcoord.xy;
 	return o;
 }

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAAPreset3.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAAPreset3.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/FXAA Preset 3" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -805,7 +807,7 @@ struct v2f {
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = v.texcoord.xy;
 	return o;
 }

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/NFAA.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/NFAA.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/NFAA" {
 Properties {
@@ -23,7 +25,7 @@ struct v2f {
 	v2f vert( appdata_img v )
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		
 		float2 uv = v.texcoord.xy;
 				

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/SSAA.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/SSAA.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/SSAA" {
 Properties {
@@ -28,7 +30,7 @@ SubShader {
 
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		
 		float2 uv = v.texcoord.xy;
 	    

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/Blend.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/Blend.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Blend" {
 	Properties {
 		_MainTex ("Screen Blended", 2D) = "" {}
@@ -26,7 +28,7 @@ Shader "Hidden/Blend" {
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv[0] =  v.texcoord.xy;
 		o.uv[1] =  v.texcoord.xy;
 		
@@ -40,7 +42,7 @@ Shader "Hidden/Blend" {
 
 	v2f_mt vertMultiTap( appdata_img v ) {
 		v2f_mt o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv[0] = v.texcoord.xy + _MainTex_TexelSize.xy * 0.5;
 		o.uv[1] = v.texcoord.xy - _MainTex_TexelSize.xy * 0.5;	
 		o.uv[2] = v.texcoord.xy - _MainTex_TexelSize.xy * half2(1,-1) * 0.5;	

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BlendForBloom.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BlendForBloom.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BlendForBloom" {
 	Properties {
 		_MainTex ("Screen Blended", 2D) = "" {}
@@ -26,7 +28,7 @@ Shader "Hidden/BlendForBloom" {
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv[0] =  v.texcoord.xy;
 		o.uv[1] =  v.texcoord.xy;
 		
@@ -40,7 +42,7 @@ Shader "Hidden/BlendForBloom" {
 
 	v2f_mt vertMultiTap( appdata_img v ) {
 		v2f_mt o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv[4] = v.texcoord.xy;
 		o.uv[0] = v.texcoord.xy + _MainTex_TexelSize.xy * 0.5;
 		o.uv[1] = v.texcoord.xy - _MainTex_TexelSize.xy * 0.5;	

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BlendOneOne.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BlendOneOne.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BlendOneOne" {
 	Properties {
 		_MainTex ("-", 2D) = "" {}
@@ -17,7 +19,7 @@ Shader "Hidden/BlendOneOne" {
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv =  v.texcoord.xy;
 		return o;
 	}

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BlurAndFlares.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BlurAndFlares.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BlurAndFlares" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -41,14 +43,14 @@ Shader "Hidden/BlurAndFlares" {
 		
 	v2f vert (appdata_img v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv =  v.texcoord.xy;
 		return o;
 	}
 
 	v2f_blur vertWithMultiCoords2 (appdata_img v) {
 		v2f_blur o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy = v.texcoord.xy;
 		o.uv01 =  v.texcoord.xyxy + _Offsets.xyxy * half4(1,1, -1,-1);
 		o.uv23 =  v.texcoord.xyxy + _Offsets.xyxy * half4(1,1, -1,-1) * 2.0;
@@ -60,7 +62,7 @@ Shader "Hidden/BlurAndFlares" {
 
 	v2f_opts vertStretch (appdata_img v) {
 		v2f_opts o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		half b = _StretchWidth;		
 		o.uv[0] = v.texcoord.xy;
 		o.uv[1] = v.texcoord.xy + b * 2.0 * _Offsets.xy;
@@ -74,7 +76,7 @@ Shader "Hidden/BlurAndFlares" {
 	
 	v2f_opts vertWithMultiCoords (appdata_img v) {
 		v2f_opts o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv[0] = v.texcoord.xy;
 		o.uv[1] = v.texcoord.xy + 0.5 * _MainTex_TexelSize.xy * _Offsets.xy;
 		o.uv[2] = v.texcoord.xy - 0.5 * _MainTex_TexelSize.xy * _Offsets.xy;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BrightPassFilter.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BrightPassFilter.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BrightPassFilterForBloom"
 {
 	Properties 
@@ -23,7 +25,7 @@ Shader "Hidden/BrightPassFilterForBloom"
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv =  v.texcoord.xy;
 		return o;
 	} 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BrightPassFilter2.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BrightPassFilter2.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BrightPassFilter2"
 {
 	Properties 
@@ -22,7 +24,7 @@ Shader "Hidden/BrightPassFilter2"
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv =  v.texcoord.xy;
 		return o;
 	} 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/LensFlareCreate.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/LensFlareCreate.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/LensFlareCreate" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -21,7 +23,7 @@ Shader "Hidden/LensFlareCreate" {
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 
 		o.uv[0] = ( ( v.texcoord.xy - 0.5 ) * -0.85 ) + 0.5;
 		o.uv[1] = ( ( v.texcoord.xy - 0.5 ) * -1.45 ) + 0.5;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/MobileBloom.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/MobileBloom.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/FastBloom" {
 	Properties {
@@ -35,7 +37,7 @@ Shader "Hidden/FastBloom" {
 		{
 			v2f_simple o;
 			
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
         	o.uv = v.texcoord;		
         	
         #if UNITY_UV_STARTS_AT_TOP
@@ -60,7 +62,7 @@ Shader "Hidden/FastBloom" {
 		{
 			v2f_tap o;
 
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
         	o.uv20 = v.texcoord + _MainTex_TexelSize.xy;				
 			o.uv21 = v.texcoord + _MainTex_TexelSize.xy * half2(-0.5h,-0.5h);	
 			o.uv22 = v.texcoord + _MainTex_TexelSize.xy * half2(0.5h,-0.5h);		
@@ -117,7 +119,7 @@ Shader "Hidden/FastBloom" {
 		v2f_withBlurCoords8 vertBlurHorizontal (appdata_img v)
 		{
 			v2f_withBlurCoords8 o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = half4(v.texcoord.xy,1,1);
 			o.offs = _MainTex_TexelSize.xy * half2(1.0, 0.0) * _Parameter.x;
@@ -128,7 +130,7 @@ Shader "Hidden/FastBloom" {
 		v2f_withBlurCoords8 vertBlurVertical (appdata_img v)
 		{
 			v2f_withBlurCoords8 o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = half4(v.texcoord.xy,1,1);
 			o.offs = _MainTex_TexelSize.xy * half2(0.0, 1.0) * _Parameter.x;
@@ -156,7 +158,7 @@ Shader "Hidden/FastBloom" {
 		v2f_withBlurCoordsSGX vertBlurHorizontalSGX (appdata_img v)
 		{
 			v2f_withBlurCoordsSGX o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = v.texcoord.xy;
 			half2 netFilterWidth = _MainTex_TexelSize.xy * half2(1.0, 0.0) * _Parameter.x; 
@@ -174,7 +176,7 @@ Shader "Hidden/FastBloom" {
 		v2f_withBlurCoordsSGX vertBlurVerticalSGX (appdata_img v)
 		{
 			v2f_withBlurCoordsSGX o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = half4(v.texcoord.xy,1,1);
 			half2 netFilterWidth = _MainTex_TexelSize.xy * half2(0.0, 1.0) * _Parameter.x;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/MobileBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/MobileBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/FastBlur" {
 	Properties {
@@ -28,7 +30,7 @@ Shader "Hidden/FastBlur" {
 		{
 			v2f_tap o;
 
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
         	o.uv20 = v.texcoord + _MainTex_TexelSize.xy;				
 			o.uv21 = v.texcoord + _MainTex_TexelSize.xy * half2(-0.5h,-0.5h);	
 			o.uv22 = v.texcoord + _MainTex_TexelSize.xy * half2(0.5h,-0.5h);		
@@ -70,7 +72,7 @@ Shader "Hidden/FastBlur" {
 		v2f_withBlurCoords8 vertBlurHorizontal (appdata_img v)
 		{
 			v2f_withBlurCoords8 o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = half4(v.texcoord.xy,1,1);
 			o.offs = _MainTex_TexelSize.xy * half2(1.0, 0.0) * _Parameter.x;
@@ -81,7 +83,7 @@ Shader "Hidden/FastBlur" {
 		v2f_withBlurCoords8 vertBlurVertical (appdata_img v)
 		{
 			v2f_withBlurCoords8 o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = half4(v.texcoord.xy,1,1);
 			o.offs = _MainTex_TexelSize.xy * half2(0.0, 1.0) * _Parameter.x;
@@ -109,7 +111,7 @@ Shader "Hidden/FastBlur" {
 		v2f_withBlurCoordsSGX vertBlurHorizontalSGX (appdata_img v)
 		{
 			v2f_withBlurCoordsSGX o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = v.texcoord.xy;
 			half2 netFilterWidth = _MainTex_TexelSize.xy * half2(1.0, 0.0) * _Parameter.x; 
@@ -127,7 +129,7 @@ Shader "Hidden/FastBlur" {
 		v2f_withBlurCoordsSGX vertBlurVerticalSGX (appdata_img v)
 		{
 			v2f_withBlurCoordsSGX o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = half4(v.texcoord.xy,1,1);
 			half2 netFilterWidth = _MainTex_TexelSize.xy * half2(0.0, 1.0) * _Parameter.x;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/MultiPassHollywoodFlares.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/MultiPassHollywoodFlares.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/MultipassHollywoodFlares" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -31,14 +33,14 @@ Shader "Hidden/MultipassHollywoodFlares" {
 		
 	v2f vert (appdata_img v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv =  v.texcoord.xy;
 		return o;
 	}
 
 	v2f_opts vertStretch (appdata_img v) {
 		v2f_opts o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		half b = stretchWidth;		
 		o.uv[0] = v.texcoord.xy;
 		o.uv[1] = v.texcoord.xy + b * 2.0 * offsets.xy;
@@ -52,7 +54,7 @@ Shader "Hidden/MultipassHollywoodFlares" {
 	
 	v2f_opts vertVerticalCoords (appdata_img v) {
 		v2f_opts o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv[0] = v.texcoord.xy;
 		o.uv[1] = v.texcoord.xy + 0.5 * _MainTex_TexelSize.xy * half2(0,1);
 		o.uv[2] = v.texcoord.xy - 0.5 * _MainTex_TexelSize.xy * half2(0,1);

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/SeparableBlurPlus.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/SeparableBlurPlus.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/SeparableBlurPlus" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -22,7 +24,7 @@ Shader "Hidden/SeparableBlurPlus" {
 		
 	v2f vert (appdata_img v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 
 		o.uv.xy = v.texcoord.xy;
 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/VignetteShader.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/VignetteShader.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/VignetteShader" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -19,7 +21,7 @@ Shader "Hidden/VignetteShader" {
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);	
+		o.pos = UnityObjectToClipPos(v.vertex);	
 		
 		o.uv = v.texcoord.xy;
 		return o;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/DepthOfField34.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/DepthOfField34.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
  Shader "Hidden/Dof/DepthOfField34" {
 	Properties {
 		_MainTex ("Base", 2D) = "" {}
@@ -46,14 +48,14 @@
 	
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv1.xy = v.texcoord.xy;
 		return o;
 	} 
 
 	v2fRadius vertWithRadius( appdata_img v ) {
 		v2fRadius o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy = v.texcoord.xy;
 
 		const half2 blurOffsets[4] = {
@@ -78,14 +80,14 @@
 	
 	v2fDofApply vertDofApply( appdata_img v ) {
 		v2fDofApply o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy = v.texcoord.xy;
 		return o;
 	} 	
 		
 	v2fDown vertDownsampleWithCocConserve(appdata_img v) {
 		v2fDown o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);	
+		o.pos = UnityObjectToClipPos(v.vertex);	
 		o.uv0.xy = v.texcoord.xy;
 		o.uv[0].xy = v.texcoord.xy + half2(-1.0,-1.0) * _InvRenderTargetSize;
 		o.uv[1].xy = v.texcoord.xy + half2(1.0,-1.0) * _InvRenderTargetSize;		

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/DepthOfFieldDX11.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/DepthOfFieldDX11.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 /*
 	DX11 Depth Of Field
@@ -159,7 +161,7 @@ Pass
 	v2f vert (appdata v)
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv = v.texcoord;
 		o.uv_flip = v.texcoord;
 		#if UNITY_UV_STARTS_AT_TOP

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/DepthOfFieldScatter.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/DepthOfFieldScatter.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
  Shader "Hidden/Dof/DepthOfFieldHdr" {
 	Properties {
 		_MainTex ("-", 2D) = "black" {}
@@ -42,7 +44,7 @@
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv1.xy = v.texcoord.xy;
 		o.uv.xy = v.texcoord.xy;
 		
@@ -57,7 +59,7 @@
 	v2f vertFlip( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv1.xy = v.texcoord.xy;
 		o.uv.xy = v.texcoord.xy;
 		
@@ -74,7 +76,7 @@
 	v2fBlur vertBlurPlusMinus (appdata_img v) 
 	{
 		v2fBlur o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy = v.texcoord.xy;
 		o.uv01 =  v.texcoord.xyxy + _Offsets.xyxy * float4(1,1, -1,-1) * _MainTex_TexelSize.xyxy / 6.0;
 		o.uv23 =  v.texcoord.xyxy + _Offsets.xyxy * float4(2,2, -2,-2) * _MainTex_TexelSize.xyxy / 6.0;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/SeparableBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/SeparableBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/SeparableBlur" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -22,7 +24,7 @@ Shader "Hidden/SeparableBlur" {
 		
 	v2f vert (appdata_img v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 
 		o.uv.xy = v.texcoord.xy;
 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/SeparableWeightedBlurDof34.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/SeparableWeightedBlurDof34.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/SeparableWeightedBlurDof34" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -34,7 +36,7 @@ Shader "Hidden/SeparableWeightedBlurDof34" {
 	
 	v2f vert (appdata_img v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy = v.texcoord.xy;
 		o.uv01 =  v.texcoord.xyxy + offsets.xyxy * half4(1,1, -1,-1);
 		o.uv23 =  v.texcoord.xyxy + offsets.xyxy * half4(1,1, -1,-1) * 2.0;
@@ -45,7 +47,7 @@ Shader "Hidden/SeparableWeightedBlurDof34" {
 	
 	v2fSingle vertSingleTex (appdata_img v) {
 		v2fSingle o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy = v.texcoord.xy;
 		return o;  
 	}	

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/TiltShiftHdrLensBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/TiltShiftHdrLensBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
  Shader "Hidden/Dof/TiltShiftHdrLensBlur" {
 	Properties {
@@ -31,7 +33,7 @@
 	v2f vert (appdata_img v) 
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv.xy = v.texcoord;
 		o.uv1.xy = v.texcoord;
 

--- a/Assets/Standard Assets/Effects/Projectors/Shaders/ProjectorLight.shader
+++ b/Assets/Standard Assets/Effects/Projectors/Shaders/ProjectorLight.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Upgrade NOTE: replaced '_Projector' with 'unity_Projector'
 // Upgrade NOTE: replaced '_ProjectorClip' with 'unity_ProjectorClip'
 
@@ -35,7 +37,7 @@ Shader "Projector/Light" {
 			v2f vert (float4 vertex : POSITION)
 			{
 				v2f o;
-				o.pos = mul (UNITY_MATRIX_MVP, vertex);
+				o.pos = UnityObjectToClipPos (vertex);
 				o.uvShadow = mul (unity_Projector, vertex);
 				o.uvFalloff = mul (unity_ProjectorClip, vertex);
 				UNITY_TRANSFER_FOG(o,o.pos);

--- a/Assets/Standard Assets/Effects/Projectors/Shaders/ProjectorMultiply.shader
+++ b/Assets/Standard Assets/Effects/Projectors/Shaders/ProjectorMultiply.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Upgrade NOTE: replaced '_Projector' with 'unity_Projector'
 // Upgrade NOTE: replaced '_ProjectorClip' with 'unity_ProjectorClip'
 
@@ -33,7 +35,7 @@ Shader "Projector/Multiply" {
 			v2f vert (float4 vertex : POSITION)
 			{
 				v2f o;
-				o.pos = mul (UNITY_MATRIX_MVP, vertex);
+				o.pos = UnityObjectToClipPos (vertex);
 				o.uvShadow = mul (unity_Projector, vertex);
 				o.uvFalloff = mul (unity_ProjectorClip, vertex);
 				UNITY_TRANSFER_FOG(o,o.pos);

--- a/Assets/Standard Assets/Effects/ToonShading/Shaders/ToonBasic.shader
+++ b/Assets/Standard Assets/Effects/ToonShading/Shaders/ToonBasic.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Toon/Basic" {
 	Properties {
 		_Color ("Main Color", Color) = (.5,.5,.5,1)
@@ -40,7 +42,7 @@ Shader "Toon/Basic" {
 			v2f vert (appdata v)
 			{
 				v2f o;
-				o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+				o.pos = UnityObjectToClipPos (v.vertex);
 				o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
 				o.cubenormal = mul (UNITY_MATRIX_MV, float4(v.normal,0));
 				UNITY_TRANSFER_FOG(o,o.pos);

--- a/Assets/Standard Assets/Effects/ToonShading/Shaders/ToonBasicOutline.shader
+++ b/Assets/Standard Assets/Effects/ToonShading/Shaders/ToonBasicOutline.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Toon/Basic Outline" {
 	Properties {
 		_Color ("Main Color", Color) = (.5,.5,.5,1)
@@ -26,7 +28,7 @@ Shader "Toon/Basic Outline" {
 	
 	v2f vert(appdata v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 
 		float3 norm   = normalize(mul ((float3x3)UNITY_MATRIX_IT_MV, v.normal));
 		float2 offset = TransformViewToProjection(norm.xy);

--- a/Assets/Standard Assets/Environment/Water (Basic)/Shaders/FXWaterBasic.shader
+++ b/Assets/Standard Assets/Environment/Water (Basic)/Shaders/FXWaterBasic.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Upgrade NOTE: replaced '_Object2World' with 'unity_ObjectToWorld'
 
 Shader "FX/Water (Basic)" {
@@ -36,7 +38,7 @@ v2f vert(appdata v)
 	v2f o;
 	float4 s;
 
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 
 	// scroll bump waves
 	float4 temp;

--- a/Assets/Standard Assets/Environment/Water/Water/Shaders/FXWaterPro.shader
+++ b/Assets/Standard Assets/Environment/Water/Water/Shaders/FXWaterPro.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Upgrade NOTE: replaced '_Object2World' with 'unity_ObjectToWorld'
 
 Shader "FX/Water" {
@@ -72,7 +74,7 @@ struct v2f {
 v2f vert(appdata v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	
 
 	// scroll bump waves

--- a/Assets/Standard Assets/Environment/Water/Water4/Shaders/FXWater4Advanced.shader
+++ b/Assets/Standard Assets/Environment/Water/Water4/Shaders/FXWater4Advanced.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Upgrade NOTE: replaced '_Object2World' with 'unity_ObjectToWorld'
 
 Shader "FX/Water4" {
@@ -156,7 +158,7 @@ CGINCLUDE
 
 		o.viewInterpolator.xyz = worldSpaceVertex - _WorldSpaceCameraPos;
 
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 
 		ComputeScreenAndGrabPassPos(o.pos, o.screenPos, o.grabPassPos);
 		
@@ -260,7 +262,7 @@ CGINCLUDE
 
 		o.viewInterpolator.xyz = worldSpaceVertex - _WorldSpaceCameraPos;
 
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 
 		o.screenPos = ComputeScreenPos(o.pos);
 		
@@ -330,7 +332,7 @@ CGINCLUDE
 
 		o.viewInterpolator.xyz = worldSpaceVertex-_WorldSpaceCameraPos;
 		
-		o.pos = mul(UNITY_MATRIX_MVP,  v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		
 		o.viewInterpolator.w = 1;//GetDistanceFadeout(ComputeScreenPos(o.pos).w, DISTANCE_SCALE);
 		

--- a/Assets/Standard Assets/Environment/Water/Water4/Shaders/FXWater4Simple.shader
+++ b/Assets/Standard Assets/Environment/Water/Water4/Shaders/FXWater4Simple.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Upgrade NOTE: replaced '_Object2World' with 'unity_ObjectToWorld'
 
 Shader "FX/SimpleWater4" {
@@ -150,7 +152,7 @@ CGINCLUDE
 
 		o.viewInterpolator.xyz = worldSpaceVertex - _WorldSpaceCameraPos;
 
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 
 		ComputeScreenAndGrabPassPos(o.pos, o.screenPos, o.grabPassPos);
 		
@@ -248,7 +250,7 @@ CGINCLUDE
 
 		o.viewInterpolator.xyz = worldSpaceVertex - _WorldSpaceCameraPos;
 
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 
 		o.screenPos = ComputeScreenPos(o.pos);
 		
@@ -317,7 +319,7 @@ CGINCLUDE
 
 		o.viewInterpolator.xyz = worldSpaceVertex-_WorldSpaceCameraPos;
 		
-		o.pos = mul(UNITY_MATRIX_MVP,  v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		
 		UNITY_TRANSFER_FOG(o,o.pos);
 		return o;

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.5.3f1
+m_EditorVersion: 2017.3.0f3

--- a/UnityPackageManager/manifest.json
+++ b/UnityPackageManager/manifest.json
@@ -1,0 +1,4 @@
+{
+	"dependencies": {
+	}
+}


### PR DESCRIPTION
In Unity 2017.3, LidarV2 constantly throws an error when accessing RawImage, even though the operation actually succeeds. Handled it with try/catch.